### PR TITLE
Fix highlighting diff of diffs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -51,7 +51,10 @@ module.exports = grammar({
     location: ($) =>
       iseq("@@", $.linerange, $.linerange, "@@", optional(ANYTHING)),
 
-    addition: ($) => iseq("+", optional(ANYTHING)),
+    addition: ($) => choice(
+      iseq("+", optional(ANYTHING)),
+      iseq("++", optional(ANYTHING)),
+    ),
     deletion: ($) =>
       choice(
         iseq("-", optional(ANYTHING)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -349,24 +349,53 @@
       ]
     },
     "addition": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "+"
-          }
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "PATTERN",
-              "value": "[^\\r\\n]+"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "+"
+              }
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^\\r\\n]+"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "++"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^\\r\\n]+"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -201,6 +201,10 @@
     "named": false
   },
   {
+    "type": "++",
+    "named": false
+  },
+  {
     "type": "+++",
     "named": false
   },

--- a/src/parser.c
+++ b/src/parser.c
@@ -8,9 +8,9 @@
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 53
 #define LARGE_STATE_COUNT 4
-#define SYMBOL_COUNT 48
+#define SYMBOL_COUNT 49
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 32
+#define TOKEN_COUNT 33
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 1
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -41,29 +41,30 @@ enum {
   anon_sym_AT_AT2 = 22,
   aux_sym_location_token1 = 23,
   anon_sym_PLUS = 24,
-  anon_sym_DASH = 25,
-  anon_sym_DASH_DASH = 26,
-  anon_sym_DASH_DASH_DASH_DASH = 27,
-  sym_context = 28,
-  sym_linerange = 29,
-  aux_sym_filename_token1 = 30,
-  sym_commit = 31,
-  sym_source = 32,
-  sym__line = 33,
-  sym_command = 34,
-  sym_file_change = 35,
-  sym_binary_change = 36,
-  sym_index = 37,
-  sym_similarity = 38,
-  sym_old_file = 39,
-  sym_new_file = 40,
-  sym_location = 41,
-  sym_addition = 42,
-  sym_deletion = 43,
-  sym_filename = 44,
-  sym_mode = 45,
-  aux_sym_source_repeat1 = 46,
-  aux_sym_filename_repeat1 = 47,
+  anon_sym_PLUS_PLUS = 25,
+  anon_sym_DASH = 26,
+  anon_sym_DASH_DASH = 27,
+  anon_sym_DASH_DASH_DASH_DASH = 28,
+  sym_context = 29,
+  sym_linerange = 30,
+  aux_sym_filename_token1 = 31,
+  sym_commit = 32,
+  sym_source = 33,
+  sym__line = 34,
+  sym_command = 35,
+  sym_file_change = 36,
+  sym_binary_change = 37,
+  sym_index = 38,
+  sym_similarity = 39,
+  sym_old_file = 40,
+  sym_new_file = 41,
+  sym_location = 42,
+  sym_addition = 43,
+  sym_deletion = 44,
+  sym_filename = 45,
+  sym_mode = 46,
+  aux_sym_source_repeat1 = 47,
+  aux_sym_filename_repeat1 = 48,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -92,6 +93,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_AT_AT2] = "@@",
   [aux_sym_location_token1] = "location_token1",
   [anon_sym_PLUS] = "+",
+  [anon_sym_PLUS_PLUS] = "++",
   [anon_sym_DASH] = "-",
   [anon_sym_DASH_DASH] = "--",
   [anon_sym_DASH_DASH_DASH_DASH] = "----",
@@ -143,6 +145,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_AT_AT2] = anon_sym_AT_AT,
   [aux_sym_location_token1] = aux_sym_location_token1,
   [anon_sym_PLUS] = anon_sym_PLUS,
+  [anon_sym_PLUS_PLUS] = anon_sym_PLUS_PLUS,
   [anon_sym_DASH] = anon_sym_DASH,
   [anon_sym_DASH_DASH] = anon_sym_DASH_DASH,
   [anon_sym_DASH_DASH_DASH_DASH] = anon_sym_DASH_DASH_DASH_DASH,
@@ -266,6 +269,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_PLUS] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PLUS_PLUS] = {
     .visible = true,
     .named = false,
   },
@@ -450,291 +457,292 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(87);
-      if (lookahead == '\n') ADVANCE(88);
+      if (eof) ADVANCE(86);
+      if (lookahead == '\n') ADVANCE(87);
       if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '%') ADVANCE(148);
-      if (lookahead == '+') ADVANCE(155);
-      if (lookahead == '-') ADVANCE(157);
-      if (lookahead == '.') ADVANCE(4);
-      if (lookahead == '@') ADVANCE(5);
-      if (lookahead == 'B') ADVANCE(38);
-      if (lookahead == 'a') ADVANCE(54);
-      if (lookahead == 'd') ADVANCE(17);
-      if (lookahead == 'f') ADVANCE(36);
-      if (lookahead == 'i') ADVANCE(56);
-      if (lookahead == 'm') ADVANCE(61);
-      if (lookahead == 'n') ADVANCE(18);
-      if (lookahead == 'r') ADVANCE(28);
-      if (lookahead == 's') ADVANCE(37);
-      if (lookahead == 't') ADVANCE(59);
-      if (('b' <= lookahead && lookahead <= 'e')) ADVANCE(81);
+      if (lookahead == '%') ADVANCE(147);
+      if (lookahead == '+') ADVANCE(154);
+      if (lookahead == '-') ADVANCE(156);
+      if (lookahead == '.') ADVANCE(3);
+      if (lookahead == '@') ADVANCE(4);
+      if (lookahead == 'B') ADVANCE(37);
+      if (lookahead == 'a') ADVANCE(53);
+      if (lookahead == 'd') ADVANCE(16);
+      if (lookahead == 'f') ADVANCE(35);
+      if (lookahead == 'i') ADVANCE(55);
+      if (lookahead == 'm') ADVANCE(60);
+      if (lookahead == 'n') ADVANCE(17);
+      if (lookahead == 'r') ADVANCE(27);
+      if (lookahead == 's') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(58);
+      if (('b' <= lookahead && lookahead <= 'e')) ADVANCE(80);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(82)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
+          lookahead == ' ') SKIP(81)
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(88);
+      if (lookahead == '\n') ADVANCE(87);
       END_STATE();
     case 2:
-      if (lookahead == '+') ADVANCE(150);
+      if (lookahead == '-') ADVANCE(34);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(195);
       END_STATE();
     case 3:
-      if (lookahead == '-') ADVANCE(35);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (lookahead == '.') ADVANCE(104);
       END_STATE();
     case 4:
-      if (lookahead == '.') ADVANCE(105);
+      if (lookahead == '@') ADVANCE(150);
       END_STATE();
     case 5:
       if (lookahead == '@') ADVANCE(151);
       END_STATE();
     case 6:
-      if (lookahead == '@') ADVANCE(152);
+      if (lookahead == 'a') ADVANCE(61);
       END_STATE();
     case 7:
-      if (lookahead == 'a') ADVANCE(62);
+      if (lookahead == 'a') ADVANCE(204);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(7)
+      if (lookahead == 11 ||
+          lookahead == '\f') ADVANCE(197);
+      if (lookahead != 0 &&
+          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(207);
       END_STATE();
     case 8:
-      if (lookahead == 'a') ADVANCE(206);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if (lookahead == 11 ||
-          lookahead == '\f') ADVANCE(199);
-      if (lookahead != 0 &&
-          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(209);
+      if (lookahead == 'a') ADVANCE(52);
       END_STATE();
     case 9:
-      if (lookahead == 'a') ADVANCE(53);
+      if (lookahead == 'a') ADVANCE(63);
       END_STATE();
     case 10:
-      if (lookahead == 'a') ADVANCE(64);
+      if (lookahead == 'd') ADVANCE(99);
       END_STATE();
     case 11:
-      if (lookahead == 'd') ADVANCE(100);
+      if (lookahead == 'd') ADVANCE(91);
       END_STATE();
     case 12:
-      if (lookahead == 'd') ADVANCE(92);
+      if (lookahead == 'd') ADVANCE(203);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(12)
+      if (lookahead == 11 ||
+          lookahead == '\f') ADVANCE(198);
+      if (lookahead != 0 &&
+          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(207);
       END_STATE();
     case 13:
-      if (lookahead == 'd') ADVANCE(205);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(13)
-      if (lookahead == 11 ||
-          lookahead == '\f') ADVANCE(200);
-      if (lookahead != 0 &&
-          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(209);
+      if (lookahead == 'd') ADVANCE(21);
       END_STATE();
     case 14:
       if (lookahead == 'd') ADVANCE(22);
       END_STATE();
     case 15:
-      if (lookahead == 'd') ADVANCE(23);
+      if (lookahead == 'd') ADVANCE(26);
       END_STATE();
     case 16:
-      if (lookahead == 'd') ADVANCE(27);
-      END_STATE();
-    case 17:
-      if (lookahead == 'e') ADVANCE(46);
-      if (lookahead == 'i') ADVANCE(31);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
-      END_STATE();
-    case 18:
-      if (lookahead == 'e') ADVANCE(69);
-      END_STATE();
-    case 19:
-      if (lookahead == 'e') ADVANCE(92);
-      END_STATE();
-    case 20:
-      if (lookahead == 'e') ADVANCE(68);
-      END_STATE();
-    case 21:
-      if (lookahead == 'e') ADVANCE(94);
-      END_STATE();
-    case 22:
-      if (lookahead == 'e') ADVANCE(70);
-      END_STATE();
-    case 23:
-      if (lookahead == 'e') ADVANCE(95);
-      END_STATE();
-    case 24:
-      if (lookahead == 'e') ADVANCE(93);
-      END_STATE();
-    case 25:
-      if (lookahead == 'e') ADVANCE(65);
-      END_STATE();
-    case 26:
-      if (lookahead == 'e') ADVANCE(63);
-      END_STATE();
-    case 27:
-      if (lookahead == 'e') ADVANCE(71);
-      END_STATE();
-    case 28:
-      if (lookahead == 'e') ADVANCE(57);
-      END_STATE();
-    case 29:
-      if (lookahead == 'e') ADVANCE(12);
-      END_STATE();
-    case 30:
-      if (lookahead == 'f') ADVANCE(90);
-      END_STATE();
-    case 31:
-      if (lookahead == 'f') ADVANCE(30);
-      END_STATE();
-    case 32:
-      if (lookahead == 'f') ADVANCE(45);
-      if (lookahead == '\t' ||
-          lookahead == 11 ||
-          lookahead == '\f' ||
-          lookahead == ' ') SKIP(32)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(81);
-      END_STATE();
-    case 33:
-      if (lookahead == 'f') ADVANCE(34);
-      END_STATE();
-    case 34:
-      if (lookahead == 'f') ADVANCE(26);
-      END_STATE();
-    case 35:
-      if (lookahead == 'g') ADVANCE(41);
-      END_STATE();
-    case 36:
-      if (lookahead == 'i') ADVANCE(47);
-      if (lookahead == 'r') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
-      END_STATE();
-    case 37:
-      if (lookahead == 'i') ADVANCE(52);
-      END_STATE();
-    case 38:
-      if (lookahead == 'i') ADVANCE(55);
-      END_STATE();
-    case 39:
-      if (lookahead == 'i') ADVANCE(50);
-      END_STATE();
-    case 40:
-      if (lookahead == 'i') ADVANCE(67);
-      END_STATE();
-    case 41:
-      if (lookahead == 'i') ADVANCE(66);
-      END_STATE();
-    case 42:
-      if (lookahead == 'i') ADVANCE(33);
-      END_STATE();
-    case 43:
-      if (lookahead == 'i') ADVANCE(33);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
-      END_STATE();
-    case 44:
-      if (lookahead == 'i') ADVANCE(48);
-      if (lookahead == 'r') ADVANCE(60);
-      END_STATE();
-    case 45:
-      if (lookahead == 'i') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
-      END_STATE();
-    case 46:
-      if (lookahead == 'l') ADVANCE(20);
+      if (lookahead == 'e') ADVANCE(45);
+      if (lookahead == 'i') ADVANCE(30);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
       END_STATE();
+    case 17:
+      if (lookahead == 'e') ADVANCE(68);
+      END_STATE();
+    case 18:
+      if (lookahead == 'e') ADVANCE(91);
+      END_STATE();
+    case 19:
+      if (lookahead == 'e') ADVANCE(67);
+      END_STATE();
+    case 20:
+      if (lookahead == 'e') ADVANCE(93);
+      END_STATE();
+    case 21:
+      if (lookahead == 'e') ADVANCE(69);
+      END_STATE();
+    case 22:
+      if (lookahead == 'e') ADVANCE(94);
+      END_STATE();
+    case 23:
+      if (lookahead == 'e') ADVANCE(92);
+      END_STATE();
+    case 24:
+      if (lookahead == 'e') ADVANCE(64);
+      END_STATE();
+    case 25:
+      if (lookahead == 'e') ADVANCE(62);
+      END_STATE();
+    case 26:
+      if (lookahead == 'e') ADVANCE(70);
+      END_STATE();
+    case 27:
+      if (lookahead == 'e') ADVANCE(56);
+      END_STATE();
+    case 28:
+      if (lookahead == 'e') ADVANCE(11);
+      END_STATE();
+    case 29:
+      if (lookahead == 'f') ADVANCE(89);
+      END_STATE();
+    case 30:
+      if (lookahead == 'f') ADVANCE(29);
+      END_STATE();
+    case 31:
+      if (lookahead == 'f') ADVANCE(44);
+      if (lookahead == '\t' ||
+          lookahead == 11 ||
+          lookahead == '\f' ||
+          lookahead == ' ') SKIP(31)
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'e')) ADVANCE(80);
+      END_STATE();
+    case 32:
+      if (lookahead == 'f') ADVANCE(33);
+      END_STATE();
+    case 33:
+      if (lookahead == 'f') ADVANCE(25);
+      END_STATE();
+    case 34:
+      if (lookahead == 'g') ADVANCE(40);
+      END_STATE();
+    case 35:
+      if (lookahead == 'i') ADVANCE(46);
+      if (lookahead == 'r') ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
+      END_STATE();
+    case 36:
+      if (lookahead == 'i') ADVANCE(51);
+      END_STATE();
+    case 37:
+      if (lookahead == 'i') ADVANCE(54);
+      END_STATE();
+    case 38:
+      if (lookahead == 'i') ADVANCE(49);
+      END_STATE();
+    case 39:
+      if (lookahead == 'i') ADVANCE(66);
+      END_STATE();
+    case 40:
+      if (lookahead == 'i') ADVANCE(65);
+      END_STATE();
+    case 41:
+      if (lookahead == 'i') ADVANCE(32);
+      END_STATE();
+    case 42:
+      if (lookahead == 'i') ADVANCE(32);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
+      END_STATE();
+    case 43:
+      if (lookahead == 'i') ADVANCE(47);
+      if (lookahead == 'r') ADVANCE(59);
+      END_STATE();
+    case 44:
+      if (lookahead == 'i') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
+      END_STATE();
+    case 45:
+      if (lookahead == 'l') ADVANCE(19);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(78);
+      END_STATE();
+    case 46:
+      if (lookahead == 'l') ADVANCE(20);
+      END_STATE();
     case 47:
-      if (lookahead == 'l') ADVANCE(21);
+      if (lookahead == 'l') ADVANCE(23);
       END_STATE();
     case 48:
       if (lookahead == 'l') ADVANCE(24);
       END_STATE();
     case 49:
-      if (lookahead == 'l') ADVANCE(25);
+      if (lookahead == 'l') ADVANCE(9);
       END_STATE();
     case 50:
-      if (lookahead == 'l') ADVANCE(10);
+      if (lookahead == 'm') ADVANCE(95);
       END_STATE();
     case 51:
-      if (lookahead == 'm') ADVANCE(96);
+      if (lookahead == 'm') ADVANCE(38);
       END_STATE();
     case 52:
-      if (lookahead == 'm') ADVANCE(39);
+      if (lookahead == 'm') ADVANCE(18);
       END_STATE();
     case 53:
-      if (lookahead == 'm') ADVANCE(19);
+      if (lookahead == 'n') ADVANCE(10);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
       END_STATE();
     case 54:
-      if (lookahead == 'n') ADVANCE(11);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
+      if (lookahead == 'n') ADVANCE(6);
       END_STATE();
     case 55:
-      if (lookahead == 'n') ADVANCE(7);
+      if (lookahead == 'n') ADVANCE(13);
       END_STATE();
     case 56:
-      if (lookahead == 'n') ADVANCE(14);
+      if (lookahead == 'n') ADVANCE(8);
       END_STATE();
     case 57:
-      if (lookahead == 'n') ADVANCE(9);
+      if (lookahead == 'n') ADVANCE(15);
       END_STATE();
     case 58:
-      if (lookahead == 'n') ADVANCE(16);
+      if (lookahead == 'o') ADVANCE(96);
       END_STATE();
     case 59:
-      if (lookahead == 'o') ADVANCE(97);
+      if (lookahead == 'o') ADVANCE(50);
       END_STATE();
     case 60:
-      if (lookahead == 'o') ADVANCE(51);
+      if (lookahead == 'o') ADVANCE(14);
       END_STATE();
     case 61:
-      if (lookahead == 'o') ADVANCE(15);
+      if (lookahead == 'r') ADVANCE(71);
       END_STATE();
     case 62:
-      if (lookahead == 'r') ADVANCE(72);
+      if (lookahead == 'r') ADVANCE(101);
       END_STATE();
     case 63:
-      if (lookahead == 'r') ADVANCE(102);
+      if (lookahead == 'r') ADVANCE(39);
       END_STATE();
     case 64:
-      if (lookahead == 'r') ADVANCE(40);
+      if (lookahead == 's') ADVANCE(98);
       END_STATE();
     case 65:
-      if (lookahead == 's') ADVANCE(99);
+      if (lookahead == 't') ADVANCE(90);
       END_STATE();
     case 66:
-      if (lookahead == 't') ADVANCE(91);
+      if (lookahead == 't') ADVANCE(72);
       END_STATE();
     case 67:
-      if (lookahead == 't') ADVANCE(73);
+      if (lookahead == 't') ADVANCE(28);
       END_STATE();
     case 68:
-      if (lookahead == 't') ADVANCE(29);
+      if (lookahead == 'w') ADVANCE(91);
       END_STATE();
     case 69:
-      if (lookahead == 'w') ADVANCE(92);
+      if (lookahead == 'x') ADVANCE(103);
       END_STATE();
     case 70:
-      if (lookahead == 'x') ADVANCE(104);
+      if (lookahead == 'x') ADVANCE(106);
       END_STATE();
     case 71:
-      if (lookahead == 'x') ADVANCE(107);
+      if (lookahead == 'y') ADVANCE(97);
       END_STATE();
     case 72:
-      if (lookahead == 'y') ADVANCE(98);
+      if (lookahead == 'y') ADVANCE(105);
       END_STATE();
     case 73:
-      if (lookahead == 'y') ADVANCE(106);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(195);
       END_STATE();
     case 74:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(196);
       END_STATE();
     case 75:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(241);
       END_STATE();
     case 76:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(243);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
       END_STATE();
     case 77:
       if (('0' <= lookahead && lookahead <= '9') ||
@@ -753,769 +761,768 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
       END_STATE();
     case 81:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
+      if (eof) ADVANCE(86);
+      if (lookahead == '\n') ADVANCE(87);
+      if (lookahead == '\r') ADVANCE(1);
+      if (lookahead == '%') ADVANCE(147);
+      if (lookahead == '.') ADVANCE(3);
+      if (lookahead == '@') ADVANCE(5);
+      if (lookahead == 'a') ADVANCE(53);
+      if (lookahead == 'd') ADVANCE(42);
+      if (lookahead == 'f') ADVANCE(35);
+      if (lookahead == 'i') ADVANCE(57);
+      if (lookahead == 'm') ADVANCE(60);
+      if (lookahead == 't') ADVANCE(58);
+      if (('b' <= lookahead && lookahead <= 'e')) ADVANCE(80);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') SKIP(81)
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
       END_STATE();
     case 82:
-      if (eof) ADVANCE(87);
-      if (lookahead == '\n') ADVANCE(88);
+      if (eof) ADVANCE(86);
+      if (lookahead == '\n') ADVANCE(87);
       if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '%') ADVANCE(148);
-      if (lookahead == '.') ADVANCE(4);
-      if (lookahead == '@') ADVANCE(6);
-      if (lookahead == 'a') ADVANCE(54);
-      if (lookahead == 'd') ADVANCE(43);
-      if (lookahead == 'f') ADVANCE(36);
-      if (lookahead == 'i') ADVANCE(58);
-      if (lookahead == 'm') ADVANCE(61);
-      if (lookahead == 't') ADVANCE(59);
-      if (('b' <= lookahead && lookahead <= 'e')) ADVANCE(81);
+      if (lookahead == '+') ADVANCE(154);
+      if (lookahead == '-') ADVANCE(156);
+      if (lookahead == '@') ADVANCE(160);
+      if (lookahead == 'B') ADVANCE(176);
+      if (lookahead == 'd') ADVANCE(167);
+      if (lookahead == 'i') ADVANCE(183);
+      if (lookahead == 'n') ADVANCE(168);
+      if (lookahead == 'r') ADVANCE(172);
+      if (lookahead == 's') ADVANCE(175);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(82)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
+          lookahead == ' ') ADVANCE(159);
+      if (lookahead != 0) ADVANCE(194);
       END_STATE();
     case 83:
-      if (eof) ADVANCE(87);
-      if (lookahead == '\n') ADVANCE(88);
+      if (eof) ADVANCE(86);
+      if (lookahead == '\n') ADVANCE(87);
       if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '+') ADVANCE(74);
-      if (lookahead == '-') ADVANCE(3);
-      if (lookahead == '@') ADVANCE(6);
-      if (lookahead == 'd') ADVANCE(42);
-      if (lookahead == 'f') ADVANCE(44);
-      if (lookahead == 'i') ADVANCE(58);
-      if (lookahead == 't') ADVANCE(59);
+      if (lookahead == '+') ADVANCE(73);
+      if (lookahead == '-') ADVANCE(2);
+      if (lookahead == '@') ADVANCE(5);
+      if (lookahead == 'd') ADVANCE(41);
+      if (lookahead == 'f') ADVANCE(43);
+      if (lookahead == 'i') ADVANCE(57);
+      if (lookahead == 't') ADVANCE(58);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(83)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(147);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(146);
       END_STATE();
     case 84:
-      if (eof) ADVANCE(87);
-      if (lookahead == '\n') ADVANCE(88);
-      if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '+') ADVANCE(156);
-      if (lookahead == '-') ADVANCE(157);
-      if (lookahead == '@') ADVANCE(162);
-      if (lookahead == 'B') ADVANCE(178);
-      if (lookahead == 'd') ADVANCE(169);
-      if (lookahead == 'i') ADVANCE(185);
-      if (lookahead == 'n') ADVANCE(170);
-      if (lookahead == 'r') ADVANCE(174);
-      if (lookahead == 's') ADVANCE(177);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(160);
-      if (lookahead != 0) ADVANCE(196);
-      END_STATE();
-    case 85:
-      if (eof) ADVANCE(87);
-      if (lookahead == '\n') ADVANCE(88);
+      if (eof) ADVANCE(86);
+      if (lookahead == '\n') ADVANCE(87);
       if (lookahead == '\r') ADVANCE(1);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(85)
+          lookahead == ' ') SKIP(84)
       if (lookahead == 11 ||
-          lookahead == '\f') ADVANCE(208);
-      if (lookahead != 0) ADVANCE(209);
+          lookahead == '\f') ADVANCE(206);
+      if (lookahead != 0) ADVANCE(207);
       END_STATE();
-    case 86:
-      if (eof) ADVANCE(87);
-      if (lookahead == '\n') ADVANCE(88);
+    case 85:
+      if (eof) ADVANCE(86);
+      if (lookahead == '\n') ADVANCE(87);
       if (lookahead == '\r') ADVANCE(1);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(153);
-      if (lookahead != 0) ADVANCE(154);
+          lookahead == ' ') ADVANCE(152);
+      if (lookahead != 0) ADVANCE(153);
       END_STATE();
-    case 87:
+    case 86:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 88:
+    case 87:
       ACCEPT_TOKEN(aux_sym_source_token1);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(anon_sym_diff);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(anon_sym_diff);
+      if (lookahead == 'e') ADVANCE(62);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(anon_sym_diff);
-      if (lookahead == 'e') ADVANCE(63);
-      END_STATE();
-    case 91:
       ACCEPT_TOKEN(anon_sym_DASH_DASHgit);
       END_STATE();
-    case 92:
+    case 91:
       ACCEPT_TOKEN(aux_sym_file_change_token1);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(anon_sym_file);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(anon_sym_file);
+      if (lookahead == 's') ADVANCE(98);
       END_STATE();
     case 94:
-      ACCEPT_TOKEN(anon_sym_file);
-      if (lookahead == 's') ADVANCE(99);
-      END_STATE();
-    case 95:
       ACCEPT_TOKEN(anon_sym_mode);
       END_STATE();
-    case 96:
+    case 95:
       ACCEPT_TOKEN(anon_sym_from);
       END_STATE();
-    case 97:
+    case 96:
       ACCEPT_TOKEN(anon_sym_to);
       END_STATE();
-    case 98:
+    case 97:
       ACCEPT_TOKEN(anon_sym_Binary);
       END_STATE();
-    case 99:
+    case 98:
       ACCEPT_TOKEN(anon_sym_files);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(anon_sym_and);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(anon_sym_and);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(anon_sym_and);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(anon_sym_differ);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(anon_sym_differ);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(anon_sym_differ);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
-    case 104:
+    case 103:
       ACCEPT_TOKEN(anon_sym_index);
       END_STATE();
-    case 105:
+    case 104:
       ACCEPT_TOKEN(anon_sym_DOT_DOT);
       END_STATE();
-    case 106:
+    case 105:
       ACCEPT_TOKEN(anon_sym_similarity);
       END_STATE();
-    case 107:
+    case 106:
       ACCEPT_TOKEN(anon_sym_index2);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(aux_sym_similarity_token1);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(241);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(145);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(243);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(208);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(146);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(210);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(147);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(107);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(76);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(209);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(108);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(211);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(109);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(210);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(110);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(212);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(77);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(111);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(78);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(211);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(112);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(213);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(78);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(113);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(212);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(114);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(214);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(79);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(115);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(80);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(213);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(116);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(215);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(214);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(216);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(215);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(217);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(216);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(218);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(217);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(121);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(219);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(218);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(122);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(220);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(219);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(123);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(221);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(220);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(124);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(222);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(221);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(125);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(223);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(222);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(126);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(224);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(223);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(127);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(225);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(224);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(128);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(226);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(225);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(129);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(226);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(130);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(228);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(131);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(229);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(228);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(132);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(230);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(229);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(133);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(231);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(230);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(134);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(232);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(231);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(135);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(233);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(232);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(136);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(234);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(233);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(137);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(234);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(138);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(236);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(139);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(237);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(236);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(140);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(238);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(237);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(141);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(239);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(238);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(142);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(240);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(239);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(143);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(241);
+      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(240);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(144);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('a' <= lookahead && lookahead <= 'f')) ADVANCE(242);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(145);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(146);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(aux_sym_similarity_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(147);
-      END_STATE();
-    case 148:
       ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
-    case 149:
+    case 148:
       ACCEPT_TOKEN(anon_sym_DASH_DASH_DASH);
-      if (lookahead == '-') ADVANCE(159);
+      if (lookahead == '-') ADVANCE(158);
       END_STATE();
-    case 150:
+    case 149:
       ACCEPT_TOKEN(anon_sym_PLUS_PLUS_PLUS);
       END_STATE();
-    case 151:
+    case 150:
       ACCEPT_TOKEN(anon_sym_AT_AT);
       END_STATE();
-    case 152:
+    case 151:
       ACCEPT_TOKEN(anon_sym_AT_AT2);
       END_STATE();
-    case 153:
+    case 152:
       ACCEPT_TOKEN(aux_sym_location_token1);
       if (lookahead == '\t' ||
           lookahead == 11 ||
           lookahead == '\f' ||
-          lookahead == ' ') ADVANCE(153);
+          lookahead == ' ') ADVANCE(152);
       if (lookahead != 0 &&
-          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(154);
+          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(153);
       END_STATE();
-    case 154:
+    case 153:
       ACCEPT_TOKEN(aux_sym_location_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(154);
+          lookahead != '\r') ADVANCE(153);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (lookahead == '+') ADVANCE(155);
       END_STATE();
     case 155:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '+') ADVANCE(2);
+      ACCEPT_TOKEN(anon_sym_PLUS_PLUS);
+      if (lookahead == '+') ADVANCE(149);
       END_STATE();
     case 156:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '+') ADVANCE(161);
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '-') ADVANCE(157);
       END_STATE();
     case 157:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '-') ADVANCE(158);
+      ACCEPT_TOKEN(anon_sym_DASH_DASH);
+      if (lookahead == '-') ADVANCE(148);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH);
-      if (lookahead == '-') ADVANCE(149);
+      ACCEPT_TOKEN(anon_sym_DASH_DASH_DASH_DASH);
       END_STATE();
     case 159:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH_DASH_DASH);
+      ACCEPT_TOKEN(sym_context);
+      if (lookahead == '\n') ADVANCE(87);
+      if (lookahead == '\r') ADVANCE(1);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(159);
+      if (lookahead != 0) ADVANCE(194);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == '\n') ADVANCE(88);
-      if (lookahead == '\r') ADVANCE(1);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(160);
-      if (lookahead != 0) ADVANCE(196);
+      if (lookahead == '@') ADVANCE(150);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 161:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == '+') ADVANCE(150);
+      if (lookahead == 'a') ADVANCE(186);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == '@') ADVANCE(151);
+      if (lookahead == 'a') ADVANCE(182);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'a') ADVANCE(188);
+      if (lookahead == 'a') ADVANCE(187);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'a') ADVANCE(184);
+      if (lookahead == 'd') ADVANCE(91);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'a') ADVANCE(189);
+      if (lookahead == 'd') ADVANCE(170);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'd') ADVANCE(92);
+      if (lookahead == 'e') ADVANCE(91);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 167:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'd') ADVANCE(172);
+      if (lookahead == 'e') ADVANCE(179);
+      if (lookahead == 'i') ADVANCE(174);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'e') ADVANCE(92);
+      if (lookahead == 'e') ADVANCE(190);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'e') ADVANCE(181);
-      if (lookahead == 'i') ADVANCE(176);
+      if (lookahead == 'e') ADVANCE(189);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'e') ADVANCE(192);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
-      END_STATE();
-    case 171:
       ACCEPT_TOKEN(sym_context);
       if (lookahead == 'e') ADVANCE(191);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
+      END_STATE();
+    case 171:
+      ACCEPT_TOKEN(sym_context);
+      if (lookahead == 'e') ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'e') ADVANCE(193);
+      if (lookahead == 'e') ADVANCE(185);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'e') ADVANCE(166);
+      if (lookahead == 'f') ADVANCE(88);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'e') ADVANCE(187);
+      if (lookahead == 'f') ADVANCE(173);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'f') ADVANCE(89);
+      if (lookahead == 'i') ADVANCE(181);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 176:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'f') ADVANCE(175);
+      if (lookahead == 'i') ADVANCE(184);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 177:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'i') ADVANCE(183);
+      if (lookahead == 'i') ADVANCE(180);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 178:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'i') ADVANCE(186);
+      if (lookahead == 'i') ADVANCE(188);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 179:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'i') ADVANCE(182);
+      if (lookahead == 'l') ADVANCE(169);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 180:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'i') ADVANCE(190);
+      if (lookahead == 'l') ADVANCE(163);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 181:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'l') ADVANCE(171);
+      if (lookahead == 'm') ADVANCE(177);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 182:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'l') ADVANCE(165);
+      if (lookahead == 'm') ADVANCE(166);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'm') ADVANCE(179);
+      if (lookahead == 'n') ADVANCE(165);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'm') ADVANCE(168);
+      if (lookahead == 'n') ADVANCE(161);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'n') ADVANCE(167);
+      if (lookahead == 'n') ADVANCE(162);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'n') ADVANCE(163);
+      if (lookahead == 'r') ADVANCE(192);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'n') ADVANCE(164);
+      if (lookahead == 'r') ADVANCE(178);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'r') ADVANCE(194);
+      if (lookahead == 't') ADVANCE(193);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'r') ADVANCE(180);
+      if (lookahead == 't') ADVANCE(171);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 't') ADVANCE(195);
+      if (lookahead == 'w') ADVANCE(91);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 't') ADVANCE(173);
+      if (lookahead == 'x') ADVANCE(103);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 192:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'w') ADVANCE(92);
+      if (lookahead == 'y') ADVANCE(97);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 193:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'x') ADVANCE(104);
+      if (lookahead == 'y') ADVANCE(105);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 194:
       ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'y') ADVANCE(98);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+          lookahead != '\r') ADVANCE(194);
       END_STATE();
     case 195:
-      ACCEPT_TOKEN(sym_context);
-      if (lookahead == 'y') ADVANCE(106);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+      ACCEPT_TOKEN(sym_linerange);
+      if (lookahead == ',') ADVANCE(74);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(195);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(sym_context);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(196);
+      ACCEPT_TOKEN(sym_linerange);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(196);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(sym_linerange);
-      if (lookahead == ',') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(197);
+      ACCEPT_TOKEN(aux_sym_filename_token1);
+      if (lookahead == 'a') ADVANCE(204);
+      if (lookahead == 11 ||
+          lookahead == '\f') ADVANCE(197);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(sym_linerange);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(198);
+      ACCEPT_TOKEN(aux_sym_filename_token1);
+      if (lookahead == 'd') ADVANCE(203);
+      if (lookahead == 11 ||
+          lookahead == '\f') ADVANCE(198);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 199:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'a') ADVANCE(206);
-      if (lookahead == 11 ||
-          lookahead == '\f') ADVANCE(199);
+      if (lookahead == 'd') ADVANCE(100);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 200:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'd') ADVANCE(205);
-      if (lookahead == 11 ||
-          lookahead == '\f') ADVANCE(200);
+      if (lookahead == 'e') ADVANCE(205);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'd') ADVANCE(101);
+      if (lookahead == 'f') ADVANCE(200);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 202:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'e') ADVANCE(207);
+      if (lookahead == 'f') ADVANCE(201);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 203:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'f') ADVANCE(202);
+      if (lookahead == 'i') ADVANCE(202);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 204:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'f') ADVANCE(203);
+      if (lookahead == 'n') ADVANCE(199);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 205:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'i') ADVANCE(204);
+      if (lookahead == 'r') ADVANCE(102);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 206:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'n') ADVANCE(201);
+      if (lookahead == 11 ||
+          lookahead == '\f') ADVANCE(206);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 207:
       ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 'r') ADVANCE(103);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+          lookahead != ' ') ADVANCE(207);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead == 11 ||
-          lookahead == '\f') ADVANCE(208);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != ' ') ADVANCE(209);
+      ACCEPT_TOKEN(sym_commit);
       END_STATE();
     case 209:
-      ACCEPT_TOKEN(aux_sym_filename_token1);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(209);
+      ACCEPT_TOKEN(sym_commit);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(208);
       END_STATE();
     case 210:
       ACCEPT_TOKEN(sym_commit);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(209);
       END_STATE();
     case 211:
       ACCEPT_TOKEN(sym_commit);
@@ -1672,16 +1679,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(240);
       END_STATE();
-    case 242:
-      ACCEPT_TOKEN(sym_commit);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(241);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(sym_commit);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(242);
-      END_STATE();
     default:
       return false;
   }
@@ -1689,26 +1686,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 84},
-  [2] = {.lex_state = 84},
-  [3] = {.lex_state = 84},
-  [4] = {.lex_state = 84},
-  [5] = {.lex_state = 85},
-  [6] = {.lex_state = 85},
-  [7] = {.lex_state = 85},
+  [1] = {.lex_state = 82},
+  [2] = {.lex_state = 82},
+  [3] = {.lex_state = 82},
+  [4] = {.lex_state = 82},
+  [5] = {.lex_state = 84},
+  [6] = {.lex_state = 84},
+  [7] = {.lex_state = 84},
   [8] = {.lex_state = 83},
-  [9] = {.lex_state = 86},
-  [10] = {.lex_state = 86},
-  [11] = {.lex_state = 86},
-  [12] = {.lex_state = 13},
-  [13] = {.lex_state = 85},
-  [14] = {.lex_state = 85},
-  [15] = {.lex_state = 85},
-  [16] = {.lex_state = 8},
-  [17] = {.lex_state = 85},
-  [18] = {.lex_state = 85},
-  [19] = {.lex_state = 8},
-  [20] = {.lex_state = 13},
+  [9] = {.lex_state = 85},
+  [10] = {.lex_state = 85},
+  [11] = {.lex_state = 85},
+  [12] = {.lex_state = 12},
+  [13] = {.lex_state = 84},
+  [14] = {.lex_state = 84},
+  [15] = {.lex_state = 84},
+  [16] = {.lex_state = 7},
+  [17] = {.lex_state = 84},
+  [18] = {.lex_state = 84},
+  [19] = {.lex_state = 7},
+  [20] = {.lex_state = 12},
   [21] = {.lex_state = 83},
   [22] = {.lex_state = 0},
   [23] = {.lex_state = 0},
@@ -1731,7 +1728,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [40] = {.lex_state = 0},
   [41] = {.lex_state = 0},
   [42] = {.lex_state = 0},
-  [43] = {.lex_state = 32},
+  [43] = {.lex_state = 31},
   [44] = {.lex_state = 0},
   [45] = {.lex_state = 83},
   [46] = {.lex_state = 0},
@@ -1739,8 +1736,8 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [48] = {.lex_state = 83},
   [49] = {.lex_state = 83},
   [50] = {.lex_state = 83},
-  [51] = {.lex_state = 32},
-  [52] = {.lex_state = 32},
+  [51] = {.lex_state = 31},
+  [52] = {.lex_state = 31},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1768,6 +1765,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_AT_AT] = ACTIONS(1),
     [anon_sym_AT_AT2] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
+    [anon_sym_PLUS_PLUS] = ACTIONS(1),
     [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_DASH_DASH] = ACTIONS(1),
     [anon_sym_DASH_DASH_DASH_DASH] = ACTIONS(1),
@@ -1798,6 +1796,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_PLUS_PLUS_PLUS] = ACTIONS(19),
     [anon_sym_AT_AT] = ACTIONS(21),
     [anon_sym_PLUS] = ACTIONS(23),
+    [anon_sym_PLUS_PLUS] = ACTIONS(23),
     [anon_sym_DASH] = ACTIONS(25),
     [anon_sym_DASH_DASH] = ACTIONS(25),
     [anon_sym_DASH_DASH_DASH_DASH] = ACTIONS(27),
@@ -1827,6 +1826,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_PLUS_PLUS_PLUS] = ACTIONS(54),
     [anon_sym_AT_AT] = ACTIONS(57),
     [anon_sym_PLUS] = ACTIONS(60),
+    [anon_sym_PLUS_PLUS] = ACTIONS(60),
     [anon_sym_DASH] = ACTIONS(63),
     [anon_sym_DASH_DASH] = ACTIONS(63),
     [anon_sym_DASH_DASH_DASH_DASH] = ACTIONS(66),
@@ -1856,6 +1856,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_PLUS_PLUS_PLUS] = ACTIONS(19),
     [anon_sym_AT_AT] = ACTIONS(21),
     [anon_sym_PLUS] = ACTIONS(23),
+    [anon_sym_PLUS_PLUS] = ACTIONS(23),
     [anon_sym_DASH] = ACTIONS(25),
     [anon_sym_DASH_DASH] = ACTIONS(25),
     [anon_sym_DASH_DASH_DASH_DASH] = ACTIONS(27),
@@ -1865,10 +1866,11 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 2,
-    ACTIONS(78), 6,
+    ACTIONS(78), 7,
       aux_sym_source_token1,
       anon_sym_DASH_DASH_DASH,
       anon_sym_PLUS,
+      anon_sym_PLUS_PLUS,
       anon_sym_DASH,
       anon_sym_DASH_DASH,
       sym_context,
@@ -1882,7 +1884,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS_PLUS_PLUS,
       anon_sym_AT_AT,
       anon_sym_DASH_DASH_DASH_DASH,
-  [20] = 5,
+  [21] = 5,
     ACTIONS(80), 1,
       ts_builtin_sym_end,
     ACTIONS(82), 1,
@@ -1893,7 +1895,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_filename_repeat1,
     STATE(23), 1,
       sym_filename,
-  [36] = 4,
+  [37] = 4,
     ACTIONS(86), 1,
       ts_builtin_sym_end,
     ACTIONS(88), 1,
@@ -1902,7 +1904,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_filename_token1,
     STATE(7), 1,
       aux_sym_filename_repeat1,
-  [49] = 4,
+  [50] = 4,
     ACTIONS(92), 1,
       ts_builtin_sym_end,
     ACTIONS(94), 1,
@@ -1911,7 +1913,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_filename_token1,
     STATE(7), 1,
       aux_sym_filename_repeat1,
-  [62] = 3,
+  [63] = 3,
     ACTIONS(101), 1,
       aux_sym_similarity_token1,
     STATE(29), 1,
@@ -1919,259 +1921,259 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(99), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [73] = 3,
+  [74] = 3,
     ACTIONS(103), 1,
       ts_builtin_sym_end,
     ACTIONS(105), 1,
       aux_sym_source_token1,
     ACTIONS(107), 1,
       aux_sym_location_token1,
-  [83] = 3,
+  [84] = 3,
     ACTIONS(109), 1,
       ts_builtin_sym_end,
     ACTIONS(111), 1,
       aux_sym_source_token1,
     ACTIONS(113), 1,
       aux_sym_location_token1,
-  [93] = 3,
+  [94] = 3,
     ACTIONS(80), 1,
       ts_builtin_sym_end,
     ACTIONS(82), 1,
       aux_sym_source_token1,
     ACTIONS(115), 1,
       aux_sym_location_token1,
-  [103] = 3,
+  [104] = 3,
     ACTIONS(94), 1,
       anon_sym_differ,
     ACTIONS(117), 1,
       aux_sym_filename_token1,
     STATE(12), 1,
       aux_sym_filename_repeat1,
-  [113] = 3,
+  [114] = 3,
     ACTIONS(120), 1,
       aux_sym_filename_token1,
     STATE(20), 1,
       aux_sym_filename_repeat1,
     STATE(45), 1,
       sym_filename,
-  [123] = 3,
+  [124] = 3,
     ACTIONS(84), 1,
       aux_sym_filename_token1,
     STATE(6), 1,
       aux_sym_filename_repeat1,
     STATE(24), 1,
       sym_filename,
-  [133] = 3,
+  [134] = 3,
     ACTIONS(84), 1,
       aux_sym_filename_token1,
     STATE(6), 1,
       aux_sym_filename_repeat1,
     STATE(30), 1,
       sym_filename,
-  [143] = 3,
+  [144] = 3,
     ACTIONS(88), 1,
       anon_sym_and,
     ACTIONS(122), 1,
       aux_sym_filename_token1,
     STATE(19), 1,
       aux_sym_filename_repeat1,
-  [153] = 3,
+  [154] = 3,
     ACTIONS(84), 1,
       aux_sym_filename_token1,
     STATE(6), 1,
       aux_sym_filename_repeat1,
     STATE(32), 1,
       sym_filename,
-  [163] = 3,
+  [164] = 3,
     ACTIONS(124), 1,
       aux_sym_filename_token1,
     STATE(16), 1,
       aux_sym_filename_repeat1,
     STATE(46), 1,
       sym_filename,
-  [173] = 3,
+  [174] = 3,
     ACTIONS(94), 1,
       anon_sym_and,
     ACTIONS(126), 1,
       aux_sym_filename_token1,
     STATE(19), 1,
       aux_sym_filename_repeat1,
-  [183] = 3,
+  [184] = 3,
     ACTIONS(88), 1,
       anon_sym_differ,
     ACTIONS(129), 1,
       aux_sym_filename_token1,
     STATE(12), 1,
       aux_sym_filename_repeat1,
-  [193] = 2,
+  [194] = 2,
     ACTIONS(131), 1,
       anon_sym_file,
     ACTIONS(133), 2,
       anon_sym_from,
       anon_sym_to,
-  [201] = 1,
+  [202] = 1,
     ACTIONS(135), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [206] = 1,
+  [207] = 1,
     ACTIONS(137), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [211] = 1,
+  [212] = 1,
     ACTIONS(139), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [216] = 1,
+  [217] = 1,
     ACTIONS(141), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [221] = 1,
+  [222] = 1,
     ACTIONS(143), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [226] = 1,
+  [227] = 1,
     ACTIONS(145), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [231] = 2,
+  [232] = 2,
     ACTIONS(147), 1,
       ts_builtin_sym_end,
     ACTIONS(149), 1,
       aux_sym_source_token1,
-  [238] = 1,
+  [239] = 1,
     ACTIONS(151), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [243] = 1,
+  [244] = 1,
     ACTIONS(153), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [248] = 2,
+  [249] = 2,
     ACTIONS(101), 1,
       aux_sym_similarity_token1,
     STATE(35), 1,
       sym_mode,
-  [255] = 1,
+  [256] = 1,
     ACTIONS(155), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [260] = 1,
+  [261] = 1,
     ACTIONS(157), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [265] = 2,
+  [266] = 2,
     ACTIONS(72), 1,
       ts_builtin_sym_end,
     ACTIONS(149), 1,
       aux_sym_source_token1,
-  [272] = 1,
+  [273] = 1,
     ACTIONS(159), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [277] = 1,
+  [278] = 1,
     ACTIONS(161), 2,
       ts_builtin_sym_end,
       aux_sym_source_token1,
-  [282] = 1,
+  [283] = 1,
     ACTIONS(163), 1,
       anon_sym_AT_AT2,
-  [286] = 1,
+  [287] = 1,
     ACTIONS(149), 1,
       aux_sym_source_token1,
-  [290] = 1,
+  [291] = 1,
     ACTIONS(165), 1,
       sym_linerange,
-  [294] = 1,
+  [295] = 1,
     ACTIONS(167), 1,
       anon_sym_DOT_DOT,
-  [298] = 1,
+  [299] = 1,
     ACTIONS(169), 1,
       anon_sym_mode,
-  [302] = 1,
+  [303] = 1,
     ACTIONS(171), 1,
       anon_sym_PERCENT,
-  [306] = 1,
+  [307] = 1,
     ACTIONS(173), 1,
       sym_commit,
-  [310] = 1,
+  [311] = 1,
     ACTIONS(175), 1,
       ts_builtin_sym_end,
-  [314] = 1,
+  [315] = 1,
     ACTIONS(177), 1,
       anon_sym_differ,
-  [318] = 1,
+  [319] = 1,
     ACTIONS(179), 1,
       anon_sym_and,
-  [322] = 1,
+  [323] = 1,
     ACTIONS(181), 1,
       aux_sym_similarity_token1,
-  [326] = 1,
+  [327] = 1,
     ACTIONS(183), 1,
       anon_sym_DASH_DASHgit,
-  [330] = 1,
+  [331] = 1,
     ACTIONS(185), 1,
       sym_linerange,
-  [334] = 1,
+  [335] = 1,
     ACTIONS(187), 1,
       anon_sym_index2,
-  [338] = 1,
+  [339] = 1,
     ACTIONS(189), 1,
       sym_commit,
-  [342] = 1,
+  [343] = 1,
     ACTIONS(191), 1,
       anon_sym_files,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(4)] = 0,
-  [SMALL_STATE(5)] = 20,
-  [SMALL_STATE(6)] = 36,
-  [SMALL_STATE(7)] = 49,
-  [SMALL_STATE(8)] = 62,
-  [SMALL_STATE(9)] = 73,
-  [SMALL_STATE(10)] = 83,
-  [SMALL_STATE(11)] = 93,
-  [SMALL_STATE(12)] = 103,
-  [SMALL_STATE(13)] = 113,
-  [SMALL_STATE(14)] = 123,
-  [SMALL_STATE(15)] = 133,
-  [SMALL_STATE(16)] = 143,
-  [SMALL_STATE(17)] = 153,
-  [SMALL_STATE(18)] = 163,
-  [SMALL_STATE(19)] = 173,
-  [SMALL_STATE(20)] = 183,
-  [SMALL_STATE(21)] = 193,
-  [SMALL_STATE(22)] = 201,
-  [SMALL_STATE(23)] = 206,
-  [SMALL_STATE(24)] = 211,
-  [SMALL_STATE(25)] = 216,
-  [SMALL_STATE(26)] = 221,
-  [SMALL_STATE(27)] = 226,
-  [SMALL_STATE(28)] = 231,
-  [SMALL_STATE(29)] = 238,
-  [SMALL_STATE(30)] = 243,
-  [SMALL_STATE(31)] = 248,
-  [SMALL_STATE(32)] = 255,
-  [SMALL_STATE(33)] = 260,
-  [SMALL_STATE(34)] = 265,
-  [SMALL_STATE(35)] = 272,
-  [SMALL_STATE(36)] = 277,
-  [SMALL_STATE(37)] = 282,
-  [SMALL_STATE(38)] = 286,
-  [SMALL_STATE(39)] = 290,
-  [SMALL_STATE(40)] = 294,
-  [SMALL_STATE(41)] = 298,
-  [SMALL_STATE(42)] = 302,
-  [SMALL_STATE(43)] = 306,
-  [SMALL_STATE(44)] = 310,
-  [SMALL_STATE(45)] = 314,
-  [SMALL_STATE(46)] = 318,
-  [SMALL_STATE(47)] = 322,
-  [SMALL_STATE(48)] = 326,
-  [SMALL_STATE(49)] = 330,
-  [SMALL_STATE(50)] = 334,
-  [SMALL_STATE(51)] = 338,
-  [SMALL_STATE(52)] = 342,
+  [SMALL_STATE(5)] = 21,
+  [SMALL_STATE(6)] = 37,
+  [SMALL_STATE(7)] = 50,
+  [SMALL_STATE(8)] = 63,
+  [SMALL_STATE(9)] = 74,
+  [SMALL_STATE(10)] = 84,
+  [SMALL_STATE(11)] = 94,
+  [SMALL_STATE(12)] = 104,
+  [SMALL_STATE(13)] = 114,
+  [SMALL_STATE(14)] = 124,
+  [SMALL_STATE(15)] = 134,
+  [SMALL_STATE(16)] = 144,
+  [SMALL_STATE(17)] = 154,
+  [SMALL_STATE(18)] = 164,
+  [SMALL_STATE(19)] = 174,
+  [SMALL_STATE(20)] = 184,
+  [SMALL_STATE(21)] = 194,
+  [SMALL_STATE(22)] = 202,
+  [SMALL_STATE(23)] = 207,
+  [SMALL_STATE(24)] = 212,
+  [SMALL_STATE(25)] = 217,
+  [SMALL_STATE(26)] = 222,
+  [SMALL_STATE(27)] = 227,
+  [SMALL_STATE(28)] = 232,
+  [SMALL_STATE(29)] = 239,
+  [SMALL_STATE(30)] = 244,
+  [SMALL_STATE(31)] = 249,
+  [SMALL_STATE(32)] = 256,
+  [SMALL_STATE(33)] = 261,
+  [SMALL_STATE(34)] = 266,
+  [SMALL_STATE(35)] = 273,
+  [SMALL_STATE(36)] = 278,
+  [SMALL_STATE(37)] = 283,
+  [SMALL_STATE(38)] = 287,
+  [SMALL_STATE(39)] = 291,
+  [SMALL_STATE(40)] = 295,
+  [SMALL_STATE(41)] = 299,
+  [SMALL_STATE(42)] = 303,
+  [SMALL_STATE(43)] = 307,
+  [SMALL_STATE(44)] = 311,
+  [SMALL_STATE(45)] = 315,
+  [SMALL_STATE(46)] = 319,
+  [SMALL_STATE(47)] = 323,
+  [SMALL_STATE(48)] = 327,
+  [SMALL_STATE(49)] = 331,
+  [SMALL_STATE(50)] = 335,
+  [SMALL_STATE(51)] = 339,
+  [SMALL_STATE(52)] = 343,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {


### PR DESCRIPTION
The symbol `+` followed by another one is valid when the diff is showing another diff, e.g. when committing a diff file to a repository.