### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /log.html
 /build/
 /*.wasm
+/.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterDiff",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterDiff", targets: ["TreeSitterDiff"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterDiff",
+                path: ".",
+                exclude: [
+                    "assets",
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "docs",
+                    "grammar.js",
+                    "LICENSE",
+                    "package-lock.json",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                    "test",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterDiff/diff.h
+++ b/bindings/swift/TreeSitterDiff/diff.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_DIFF_H_
+#define TREE_SITTER_DIFF_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_diff();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_DIFF_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. I maintain the tree-sitter Swift binding here https://github.com/chimeHQ/SwiftTreeSitter

Here are some examples of other PRs:

https://github.com/tree-sitter/tree-sitter-go/pull/79
https://github.com/tree-sitter/tree-sitter-c/pull/105
https://github.com/tree-sitter/tree-sitter-haskell/pull/91

These are manually created. They should not ever impact the parser. There no need for you to publish packages or take action for releases. The exclude patterns are pretty safe to get out of sync. They can, in some circumstances, generate warnings for Swift users. But, it's really minor.