### PR TITLE
feat: support changing file modes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -67,12 +67,10 @@ module.exports = grammar({
     command: ($) => iseq("diff", alias(/[-\w]+/, $.argument), $.filename),
 
     file_change: ($) =>
-      iseq(
-        field("kind", choice("new", "deleted", "rename")),
-        choice(
-          seq("file", "mode", $.mode),
-          seq(choice("from", "to"), $.filename)
-        )
+      choice(
+        seq(choice("new", "deleted"), "file", "mode", $.mode),
+        seq(choice("new", "old"), "mode", $.mode),
+        seq("rename", choice("from", "to"), $.filename)
       ),
 
     binary_change: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -64,7 +64,7 @@ module.exports = grammar({
         )
       ),
 
-    command: ($) => iseq("diff", /[-\w]+/, $.filename),
+    command: ($) => iseq("diff", alias(/[-\w]+/, $.argument), $.filename),
 
     file_change: ($) =>
       iseq(

--- a/grammar.js
+++ b/grammar.js
@@ -80,7 +80,7 @@ module.exports = grammar({
 
     index: ($) => iseq("index", $.commit, "..", $.commit, optional($.mode)),
 
-    similarity: ($) => iseq("similarity", "index", field("score", /\d+/), "%"),
+    similarity: ($) => iseq("similarity", "index", alias(/\d+/, $.score), "%"),
 
     old_file: ($) => iseq("---", $.filename),
     new_file: ($) => iseq("+++", $.filename),

--- a/test/corpus/binary.txt
+++ b/test/corpus/binary.txt
@@ -10,6 +10,7 @@ Binary files a/tree-sitter-gitdiff.wasm and b/tree-sitter-gitdiff.wasm differ
 (source
   (block
     (command
+      (argument)
       (filename))
     (index
       (commit)
@@ -32,6 +33,7 @@ Binary files a/docs/playground.png and /dev/null differ
 (source
   (block
     (command
+      (argument)
       (filename))
     (file_change
       (mode))

--- a/test/corpus/text.txt
+++ b/test/corpus/text.txt
@@ -21,6 +21,7 @@ index dc36969..f37fde0 100644
 (source
   (block
     (command
+      (argument)
       (filename))
     (index
       (commit)
@@ -57,6 +58,7 @@ index 0000000..e69de29
 (source
   (block
     (command
+      (argument)
       (filename))
     (file_change
       (mode))
@@ -76,6 +78,7 @@ index e69de29..0000000
 (source
   (block
     (command
+      (argument)
       (filename))
     (file_change
       (mode))
@@ -96,6 +99,7 @@ rename to tmp.md
 (source
   (block
     (command
+      (argument)
       (filename))
     (similarity)
     (file_change
@@ -132,6 +136,7 @@ index 00000000..ee9808dc
 (source
   (block
     (command
+      (argument)
       (filename))
     (file_change
       (mode))
@@ -197,6 +202,7 @@ index 321c90a..b4a5cba 100644
 (source
   (block
     (command
+      (argument)
       (filename))
     (index
       (commit)
@@ -221,6 +227,7 @@ index 321c90a..b4a5cba 100644
           (context)))))
   (block
     (command
+      (argument)
       (filename))
     (index
       (commit)

--- a/test/corpus/text.txt
+++ b/test/corpus/text.txt
@@ -101,7 +101,8 @@ rename to tmp.md
     (command
       (argument)
       (filename))
-    (similarity)
+    (similarity
+      (score))
     (file_change
       (filename))
     (file_change

--- a/test/corpus/text.txt
+++ b/test/corpus/text.txt
@@ -284,3 +284,22 @@ Leading plus additions
   (addition)
   (addition)
   (addition))
+
+================================================================================
+File mode changes
+================================================================================
+diff --git a/LICENSE b/LICENSE
+old mode 100644
+new mode 100755
+
+--------------------------------------------------------------------------------
+
+(source
+  (block
+    (command
+      (argument)
+      (filename))
+    (file_change
+      (mode))
+    (file_change
+      (mode))))


### PR DESCRIPTION
This commit also properly exposes the similarity index as a node (previously `field` would not work for anonymous regex nodes). It also updates the Tree-sitter version, which generated the associated new bindings.

EDIT: It also exposes the argument portion of the `(command)` node