### PR TITLE
fix(queries): remove unreachable location patterns

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -10,7 +10,6 @@
           (context) @injection.content
           (addition) @injection.content
           (deletion)
-          (location)
         ]+)))
   (#offset! @injection.content 0 1 0 1))
 
@@ -25,6 +24,5 @@
           (context) @injection.content
           (addition)
           (deletion) @injection.content
-          (location)
         ]+)))
   (#offset! @injection.content 0 1 0 1))

--- a/test/corpus/text.txt
+++ b/test/corpus/text.txt
@@ -48,6 +48,55 @@ index dc36969..f37fde0 100644
           (context))))))
 
 ================================================================================
+Multiple hunks
+================================================================================
+diff --git a/foo.lua b/foo.lua
+index 1234567..89abcde 100644
+--- a/foo.lua
++++ b/foo.lua
+@@ -1,2 +1,2 @@
+ local a = 1
+-local b = 2
++local b = 3
+@@ -10,2 +10,2 @@
+ local x = 1
+-local y = 2
++local y = 3
+
+--------------------------------------------------------------------------------
+
+(source
+  (block
+    (command
+      (argument)
+      (filename))
+    (index
+      (commit)
+      (commit)
+      (mode))
+    (old_file
+      (filename))
+    (new_file
+      (filename))
+    (hunks
+      (hunk
+        (location
+          (linerange)
+          (linerange))
+        (changes
+          (context)
+          (deletion)
+          (addition)))
+      (hunk
+        (location
+          (linerange)
+          (linerange))
+        (changes
+          (context)
+          (deletion)
+          (addition))))))
+
+================================================================================
 Single-file small change with preceding empty context
 ================================================================================
 diff --git a/grammar.js b/grammar.js


### PR DESCRIPTION
i'm pretty sure that this location can never match, since it always comes before the `@@..@` header