### PR TITLE
fix(queries): continue injections past non-change lines

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -10,6 +10,9 @@
           (context) @injection.content
           (addition) @injection.content
           (deletion)
+          (special)
+          (change)
+          (unrecognized)
         ]+)))
   (#offset! @injection.content 0 1 0 1))
 
@@ -24,5 +27,8 @@
           (context) @injection.content
           (addition)
           (deletion) @injection.content
+          (special)
+          (change)
+          (unrecognized)
         ]+)))
   (#offset! @injection.content 0 1 0 1))


### PR DESCRIPTION
Consider the following diff, which creates a diff with no newline at the end:

```zsh
cd /tmp && printf 'local a = 1\nlocal b = 2' > a.lua && printf 'local a = 1\nlocal b = 3' > b.lua && diff -u a.lua b.lua
```

current queries fail to capture the final `local b = 3`. this is because diff appends this string:

```
\ No newline at end of file
``` 

which we aren't properly respecting