### PR TITLE
fix(queries): strip timestamps and quotes from filenames

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -14,7 +14,9 @@
           (change)
           (unrecognized)
         ]+)))
-  (#offset! @injection.content 0 1 0 1))
+  (#offset! @injection.content 0 1 0 1)
+  (#gsub! @injection.filename "\t.*$" "")
+  (#gsub! @injection.filename "^\"(.+)\"$" "%1"))
 
 ; deletions
 (block
@@ -31,4 +33,6 @@
           (change)
           (unrecognized)
         ]+)))
-  (#offset! @injection.content 0 1 0 1))
+  (#offset! @injection.content 0 1 0 1)
+  (#gsub! @injection.filename "\t.*$" "")
+  (#gsub! @injection.filename "^\"(.+)\"$" "%1"))


### PR DESCRIPTION
## Problem

Right now in the parser whitespace is an extra and filename is `repeat1(/\S+/)`. ths means that unified diff timestamps land inside the node *and* quoted paths keep their quotes, and the hunk then gets no highlighting since the languages aren't detected correctly!

example:

```diff
--- foo.lua     2026-01-01 12:00:00.000000000 +0000
+++ bar.lua     2026-01-02 12:00:00.000000000 +0000
@@ -1,2 +1,2 @@
 local x = 1
+local y = 2
```

## Solution

Normalize `@injection.filename` with two #gsub! before it reaches the language lookup. Solution inspired by @ribru17's comment on neovim/neovim#40851